### PR TITLE
Update PFx8MB.dat

### DIFF
--- a/ldraw/PFx8MB.dat
+++ b/ldraw/PFx8MB.dat
@@ -1,4 +1,4 @@
-0 PFx 8 MB IR
+0 PFx 8 MB
 0 Name: PFx8MB.dat
 0 Author: Fx Bricks
 0 Unofficial Model
@@ -10,5 +10,4 @@
 1 383 4 -39 37 1 0 0 0 0 -1 0 1 0 s\USBShell.dat
 1 0 4 -44 37 1 0 0 0 0 -1 0 1 0 s\USBPinHousing.dat
 1 334 4 -39 37 1 0 0 0 0 -1 0 1 0 s\USBPins.dat
-1 40 30 -72 10 -1 0 0 0 1 0 0 0 -1 3065.dat
 0


### PR DESCRIPTION
incorrectly labeled, and the trans black brick shouldnt be over the IR port on the non-IR version.