### PR TITLE
Update PFx16MB.dat

### DIFF
--- a/ldraw/PFx16MB.dat
+++ b/ldraw/PFx16MB.dat
@@ -1,4 +1,4 @@
-0 PFx 16 MB IR
+0 PFx 16 MB
 0 Name: PFx16MB.dat
 0 Author: Fx Bricks
 0 Unofficial Model
@@ -10,5 +10,4 @@
 1 383 4 -39 37 1 0 0 0 0 -1 0 1 0 s\USBShell.dat
 1 0 4 -44 37 1 0 0 0 0 -1 0 1 0 s\USBPinHousing.dat
 1 334 4 -39 37 1 0 0 0 0 -1 0 1 0 s\USBPins.dat
-1 40 30 -72 10 -1 0 0 0 1 0 0 0 -1 3065.dat
 0


### PR DESCRIPTION
incorrectly labeled, and the trans black brick shouldnt be over the IR port on the non-IR version.